### PR TITLE
fix: use role from devetek to install go binary

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -13,8 +13,11 @@ roles:
     version: v2.0.0
   - name: geerlingguy.git
     version: 3.0.1
+  # - name: gantsign.golang
+  #   version: 3.5.0
   - name: gantsign.golang
-    version: 3.5.0
+    src: https://github.com/devetek/ansible-role-golang
+    version: fix-mirror
   - name: geerlingguy.mysql
     version: 4.3.4
   - name: geerlingguy.postgresql


### PR DESCRIPTION
Issue based on: https://github.com/golang/go/issues/76673

PR open to origin code: https://github.com/gantsign/ansible-role-golang/pull/421